### PR TITLE
dns getaddrinfo 资源应及时释放

### DIFF
--- a/MQTTClient-C/mqtt_client.c
+++ b/MQTTClient-C/mqtt_client.c
@@ -293,6 +293,12 @@ static int net_connect(mqtt_client *c)
     LOG_E("resolve uri err");
     goto _exit;
   }
+  if (addr_res)
+  {
+    freeaddrinfo(addr_res);
+    addr_res = RT_NULL;
+  }
+
   
 #ifdef MQTT_USING_TLS
   if (c->tls_session)


### PR DESCRIPTION
在mqtt_resolve_uri 中，调用了 getaddrinfo，直到 _exit时才释放，但中途mbedtls_client_connect 又会再次使用此函数，此函数不可重入，会直接导致失败。

此处可安全提前释放资源。

之前提交的PR，使用 github 的编辑器，会自动转换 gbk to utf8，不方便查看，故重新提交。